### PR TITLE
[Feat] Add Clear Code button

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,7 +3,7 @@ import Editor from "./Editor";
 import useLocalStorage from "../hooks/useLocalStorage";
 import Split from "react-split";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDownload } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faEraser } from "@fortawesome/free-solid-svg-icons";
 
 function App() {
     const [html, setHtml] = useLocalStorage("html", "");
@@ -52,6 +52,12 @@ function App() {
         jsLink.download = jsDownloadFile;
     };
 
+    const clearEditor = () => {
+        setHtml("");
+        setCss("");
+        setJs("");
+    }
+
     useEffect(() => {
         if (title === "") {
             document.title = "Sketchify - Untitled";
@@ -95,6 +101,11 @@ function App() {
                     autoComplete="off"
                 />
                 <div className="download-btn">
+                    <a
+                        onClick={clearEditor}>
+                        <FontAwesomeIcon icon={faEraser} />
+                        <div>Clear Editor</div>
+                    </a>
                     <a
                         href=" "
                         id="download-btn-html"

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -100,7 +100,7 @@ function App() {
                     }
                     autoComplete="off"
                 />
-                <div className="download-btn">
+                <div className="btn-container">
                     <div
                         className="clearCode"
                         onClick={clearEditor}>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -101,11 +101,12 @@ function App() {
                     autoComplete="off"
                 />
                 <div className="download-btn">
-                    <a
+                    <div
+                        className="clearCode"
                         onClick={clearEditor}>
                         <FontAwesomeIcon icon={faEraser} />
-                        <div>Clear Editor</div>
-                    </a>
+                        <div>Clear Code</div>
+                    </div>
                     <a
                         href=" "
                         id="download-btn-html"

--- a/src/index.css
+++ b/src/index.css
@@ -35,7 +35,20 @@ body,
     cursor: pointer;
 }
 
+.download-btn > div {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 0px 10px;
+    text-decoration: none;
+    cursor: pointer;
+}
+
 .download-btn > a > svg > path {
+    fill: #7c7c7c;
+}
+
+.download-btn > div > svg > path {
     fill: #7c7c7c;
 }
 
@@ -43,11 +56,25 @@ body,
     fill: #ffffff;
 }
 
+.download-btn > div:hover > svg > path {
+    fill: #ffffff;
+}
+
 .download-btn > a:hover > div {
     color: #ffffff;
 }
 
+.download-btn > div:hover > div {
+    color: #ffffff;
+}
+
 .download-btn > a > div {
+    font-family: "Rubik";
+    padding-left: 5px;
+    color: #7c7c7c;
+}
+
+.download-btn > div > div {
     font-family: "Rubik";
     padding-left: 5px;
     color: #7c7c7c;

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,7 @@ body,
     align-items: center;
     padding: 0px 10px;
     text-decoration: none;
+    cursor: pointer;
 }
 
 .download-btn > a > svg > path {

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@ body,
 }
 
 .nav-bar,
-.download-btn {
+.btn-container {
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,7 @@ body,
     align-items: center;
 }
 
-.download-btn > a {
+.btn-container > a {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -35,7 +35,7 @@ body,
     cursor: pointer;
 }
 
-.download-btn > div {
+.btn-container > div {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -44,37 +44,37 @@ body,
     cursor: pointer;
 }
 
-.download-btn > a > svg > path {
+.btn-container > a > svg > path {
     fill: #7c7c7c;
 }
 
-.download-btn > div > svg > path {
+.btn-container > div > svg > path {
     fill: #7c7c7c;
 }
 
-.download-btn > a:hover > svg > path {
+.btn-container > a:hover > svg > path {
     fill: #ffffff;
 }
 
-.download-btn > div:hover > svg > path {
+.btn-container > div:hover > svg > path {
     fill: #ffffff;
 }
 
-.download-btn > a:hover > div {
+.btn-container > a:hover > div {
     color: #ffffff;
 }
 
-.download-btn > div:hover > div {
+.btn-container > div:hover > div {
     color: #ffffff;
 }
 
-.download-btn > a > div {
+.btn-container > a > div {
     font-family: "Rubik";
     padding-left: 5px;
     color: #7c7c7c;
 }
 
-.download-btn > div > div {
+.btn-container > div > div {
     font-family: "Rubik";
     padding-left: 5px;
     color: #7c7c7c;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Sketchify here: https://github.com/s-katte/Sketchify/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Link to the Issue

https://github.com/s-katte/Sketchify/issues/47

## Description of your PR
This PR adds the Clear Editor button to the Navbar. The button simple changes the HTML, CSS and JS states to an empty string.

(Provide a description of what this PR does.)

## Screenshots (if applicable)

![clear-editor](https://user-images.githubusercontent.com/10249593/96903664-09f69a80-148e-11eb-8eab-62fdf3e83e49.gif)

![image](https://user-images.githubusercontent.com/10249593/96903765-27c3ff80-148e-11eb-8e3b-77216f097365.png)



## Test Plan

- Write something for HTML, CSS and for JS
- Click the button
- Check if the editor is now empty

### Have you read the [Contributing Guidelines](https://github.com/s-katte/React-Code-Pen/blob/master/CONTRIBUTING.md)?

Yes (:
